### PR TITLE
Pass no_aggs=true when requesting metadata

### DIFF
--- a/src/api/complaints.js
+++ b/src/api/complaints.js
@@ -87,7 +87,7 @@ export const complaintsApi = createApi({
     }),
     getMeta: builder.query({
       query: () => ({
-        url: `?field=all&size=0`,
+        url: `?field=all&size=0&no_aggs=true`,
       }),
     }),
     getSuggest: builder.query({


### PR DESCRIPTION
On page load the app makes a small request to find out when the complaint data was last updated, currently:

?field=all&size=0

The response to this query is used in two places:

1. querySlice.js uses _meta.last_updated to set the bounds on the date filter. This is the date of the last received complaint.
2. SearchPanel.js uses _meta.last_indexed to display the last index date in the "last updated" message in the header. This is the last time the pipeline was run.

Nothing else from this query response is used, specifically the aggregations (filter counts) - these get populated by a subsequent query.

For this reason, we can pass no_aggs=true to disable computation of aggregations for this metadata query. This greatly reduces both the cost of the query as well as the size of the returned data.

Note: this won't actually work until https://github.com/cfpb/ccdb5-api/pull/248 is deployed, but it won't break anything if merged before then.