### PR TITLE
Add link to release notes

### DIFF
--- a/src/components/search/hero/hero.js
+++ b/src/components/search/hero/hero.js
@@ -39,6 +39,15 @@ export const Hero = () => {
             label="Technical documentation"
           />
         </li>
+        <li className="m-list__item">
+          <Link
+            to="https://cfpb.github.io/api/ccdb/release-notes.html"
+            iconRight="external-link"
+            target="_blank"
+            rel="noopener noreferrer"
+            label="Release notes"
+          />
+        </li>
       </ul>
     </header>
   );


### PR DESCRIPTION
Adds a link to the release notes, per DATAP-2048

<img width="1213" height="520" alt="Screenshot 2026-08-05 at 3 12 19 PM" src="https://github.com/user-attachments/assets/b1a366bc-e9f3-487b-a6b2-63f3b1adf3b7" />
